### PR TITLE
Add basic project skeleton

### DIFF
--- a/appflow/README.md
+++ b/appflow/README.md
@@ -1,0 +1,3 @@
+# AppFlow
+
+Ce dossier contient le code source principal de l'application AppFlow. Le back-end Python se trouve dans `main/` et l'interface Electron dans `frontend/`.

--- a/appflow/frontend/main.js
+++ b/appflow/frontend/main.js
@@ -1,0 +1,16 @@
+const { app, BrowserWindow } = require('electron');
+const path = require('path');
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 800,
+    height: 600,
+    webPreferences: {
+      nodeIntegration: true
+    }
+  });
+
+  win.loadFile(path.join(__dirname, 'public/index.html'));
+}
+
+app.whenReady().then(createWindow);

--- a/appflow/frontend/package.json
+++ b/appflow/frontend/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "appflow",
+  "version": "0.1.0",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron ."
+  },
+  "devDependencies": {
+    "electron": "^25.0.0"
+  }
+}

--- a/appflow/frontend/public/index.html
+++ b/appflow/frontend/public/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <title>AppFlow</title>
+</head>
+<body>
+  <h1>Welcome to AppFlow</h1>
+</body>
+</html>

--- a/appflow/main/appflow.py
+++ b/appflow/main/appflow.py
@@ -1,0 +1,29 @@
+import yaml
+import psutil
+import subprocess
+import time
+from pathlib import Path
+
+from core.rule_engine import RuleEngine
+
+
+RULES_DIR = Path(__file__).resolve().parent.parent / "rules"
+
+
+def load_rules():
+    rules = []
+    for rule_file in RULES_DIR.glob("*.yaml"):
+        with open(rule_file, 'r', encoding='utf-8') as f:
+            data = yaml.safe_load(f)
+            rules.extend(data)
+    return rules
+
+
+def main():
+    rules = load_rules()
+    engine = RuleEngine(rules)
+    engine.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/appflow/main/core/rule_engine.py
+++ b/appflow/main/core/rule_engine.py
@@ -1,0 +1,31 @@
+import subprocess
+import time
+import psutil
+
+
+class RuleEngine:
+    def __init__(self, rules):
+        self.rules = [Rule(r) for r in rules]
+
+    def run(self):
+        for rule in self.rules:
+            rule.execute()
+
+
+class Rule:
+    def __init__(self, data):
+        self.name = data.get('name', 'Unnamed')
+        self.triggers = data.get('triggers', [])
+        self.actions = data.get('actions', [])
+
+    def execute(self):
+        # For simplicity, execute all actions sequentially without triggers
+        for action in self.actions:
+            if 'launch' in action:
+                subprocess.Popen(action['launch'], shell=True)
+            elif 'kill' in action:
+                for p in psutil.process_iter(['name']):
+                    if p.info['name'] == action['kill']:
+                        p.terminate()
+            elif 'wait' in action:
+                time.sleep(action['wait'])

--- a/appflow/main/requirements.txt
+++ b/appflow/main/requirements.txt
@@ -1,0 +1,3 @@
+psutil
+pyyaml
+schedule

--- a/appflow/main/utils/system.py
+++ b/appflow/main/utils/system.py
@@ -1,0 +1,12 @@
+import subprocess
+import psutil
+
+def launch_process(cmd):
+    return subprocess.Popen(cmd, shell=True)
+
+def kill_process(name):
+    for p in psutil.process_iter(['name']):
+        if p.info['name'] == name:
+            p.terminate()
+            return True
+    return False

--- a/appflow/rules/default.yaml
+++ b/appflow/rules/default.yaml
@@ -1,0 +1,7 @@
+- name: Sample Workflow
+  triggers:
+    - app_start: "example.exe"
+  actions:
+    - launch: "notepad.exe"
+    - wait: 2
+    - kill: "calc.exe"


### PR DESCRIPTION
## Summary
- initialize `appflow` project structure with Python backend and Electron frontend
- implement simple rule engine and example rule
- provide minimal Electron setup and HTML page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ed7e836d483229814e4341cfe6947