### PR TITLE
Improve Electron frontend

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,5 +7,8 @@
   },
   "devDependencies": {
     "electron": "^25.0.0"
+  },
+  "dependencies": {
+    "js-yaml": "^4.1.0"
   }
 }

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -6,5 +6,9 @@
 </head>
 <body>
   <h1>Welcome to AppFlow</h1>
+  <h2>Règles disponibles</h2>
+  <ul id="rules"></ul>
+
+  <script src="renderer.js"></script>
 </body>
 </html>

--- a/frontend/public/renderer.js
+++ b/frontend/public/renderer.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+function loadRules() {
+  const rulesDir = path.resolve(__dirname, '../../rules');
+  const files = fs.readdirSync(rulesDir).filter(f => f.endsWith('.yaml'));
+  const rules = [];
+  for (const file of files) {
+    const content = fs.readFileSync(path.join(rulesDir, file), 'utf8');
+    try {
+      const data = yaml.load(content);
+      if (Array.isArray(data)) {
+        rules.push(...data);
+      }
+    } catch (err) {
+      console.error('Failed to parse', file, err);
+    }
+  }
+  return rules;
+}
+
+function renderRules(rules) {
+  const list = document.getElementById('rules');
+  if (!list) return;
+  list.innerHTML = '';
+  for (const r of rules) {
+    const li = document.createElement('li');
+    li.textContent = r.name || 'Unnamed rule';
+    list.appendChild(li);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const rules = loadRules();
+  renderRules(rules);
+});


### PR DESCRIPTION
## Summary
- add js-yaml dependency
- display available rules in Electron UI

## Testing
- `pip install -r main/requirements.txt` *(fails: Tunnel connection failed)*
- `npm install` *(fails: 403 Forbidden)*
- `npm run start` *(fails: electron not found)*

------
https://chatgpt.com/codex/tasks/task_e_68504ca817e4832282ea854096c58e76