### PR TITLE
Improve CLI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ L'interface est une app Electron avec React (ou Vue/Svelte selon choix). Elle co
 
 ---
 
+### Variables d'environnement utiles
+
+- `APPFLOW_RULES_DIR` : chemin vers le répertoire de règles par défaut.
+
+---
+
 ## 🧪 Exemple de règle YAML
 
 ```yaml
@@ -108,6 +114,10 @@ L'interface est une app Electron avec React (ou Vue/Svelte selon choix). Elle co
 | `python appflow.py --list` | Affiche les règles disponibles |
 | `python appflow.py --run "Nom"` | Exécute une règle précise |
 | `python appflow.py --log appflow.log` | Enregistre l'exécution dans un fichier |
+| `python appflow.py --profile work` | Charge aussi `default.yaml` puis les fichiers du profil `work` (alias `-p`) |
+| `python appflow.py --rules-dir ~/my_rules` | Charge les règles depuis un répertoire personnalisé (alias `-d`) |
+| `python appflow.py --interval 5` | Définit l'intervalle de polling en secondes (alias `-i`) |
+| `python appflow.py --once` | Exécute les règles une seule fois puis quitte (alias `-1`) |
 
 ---
 

--- a/main/appflow.py
+++ b/main/appflow.py
@@ -1,17 +1,48 @@
+from __future__ import annotations
+
 import argparse
+import os
 from pathlib import Path
 import yaml
 
 from core.rule_engine import RuleEngine
 
 
-RULES_DIR = Path(__file__).resolve().parent.parent / "rules"
+DEFAULT_RULES_DIR = Path(__file__).resolve().parent.parent / "rules"
 
 
-def load_rules():
-    """Load all YAML rule files from the rules directory."""
-    rules = []
-    for rule_file in RULES_DIR.glob("*.yaml"):
+def load_rules(profile: str | None = None, rules_dir: Path | None = None) -> list[dict]:
+    """Load YAML rule files from *rules_dir*.
+
+    Always load ``default.yaml`` if present. When ``profile`` is specified,
+    additional files from ``<rules_dir>/<profile>.yaml`` and ``<rules_dir>/<profile>/``
+    are loaded if they exist.
+    """
+
+    if rules_dir is None:
+        env_dir = os.getenv("APPFLOW_RULES_DIR")
+        rules_dir = Path(env_dir) if env_dir else DEFAULT_RULES_DIR
+
+    files: list[Path] = []
+
+    default_file = rules_dir / "default.yaml"
+    if default_file.exists():
+        files.append(default_file)
+
+    if profile:
+        profile_file = rules_dir / f"{profile}.yaml"
+        if profile_file.exists():
+            files.append(profile_file)
+        profile_dir = rules_dir / profile
+        if profile_dir.is_dir():
+            files.extend(sorted(profile_dir.glob("*.yaml")))
+
+    if not files:
+        return []
+
+    rules: list[dict] = []
+
+    for rule_file in files:
         with open(rule_file, "r", encoding="utf-8") as f:
             data = yaml.safe_load(f)
             if isinstance(data, list):
@@ -24,9 +55,36 @@ def main(argv=None):
     parser.add_argument("--list", action="store_true", help="List available rules")
     parser.add_argument("--run", metavar="RULE", help="Run a specific rule by name")
     parser.add_argument("--log", metavar="FILE", help="Write execution log to FILE")
+    parser.add_argument(
+        "--profile",
+        "-p",
+        metavar="NAME",
+        help="Also load default.yaml then rules for profile NAME",
+    )
+    parser.add_argument(
+        "--rules-dir",
+        "-d",
+        metavar="DIR",
+        help="Load rules from DIR instead of the default rules directory",
+        type=Path,
+    )
+    parser.add_argument(
+        "--interval",
+        "-i",
+        metavar="SEC",
+        type=float,
+        default=2.0,
+        help="Polling interval in seconds",
+    )
+    parser.add_argument(
+        "--once",
+        "-1",
+        action="store_true",
+        help="Check rules once and exit",
+    )
     args = parser.parse_args(argv)
 
-    rules = load_rules()
+    rules = load_rules(profile=args.profile, rules_dir=args.rules_dir)
 
     if args.list:
         for r in rules:
@@ -36,9 +94,15 @@ def main(argv=None):
     if args.run:
         rules = [r for r in rules if r.get("name") == args.run]
 
-    engine = RuleEngine(rules, log_path=args.log)
+    engine = RuleEngine(
+        rules,
+        poll_interval=args.interval,
+        log_path=args.log,
+        run_once=args.once,
+    )
     engine.run()
 
 
 if __name__ == "__main__":
     main()
+

--- a/main/core/rule_engine.py
+++ b/main/core/rule_engine.py
@@ -18,10 +18,11 @@ from utils.logger import log_event
 class RuleEngine:
     """Simple engine that evaluates rules and executes matching actions."""
 
-    def __init__(self, rules, poll_interval: float = 2.0, log_path=None):
+    def __init__(self, rules, poll_interval: float = 2.0, log_path=None, run_once: bool = False):
         self.rules = [Rule(r) for r in rules]
         self.poll_interval = poll_interval
         self.log_path = log_path
+        self.run_once = run_once
 
     def run(self):
         """Continuously check rules and execute them when triggers match."""
@@ -31,6 +32,8 @@ class RuleEngine:
                 for rule in self.rules:
                     if rule.check_triggers():
                         rule.execute(log_path=self.log_path)
+                if self.run_once:
+                    break
                 time.sleep(self.poll_interval)
         except KeyboardInterrupt:
             print("Rule engine stopped")


### PR DESCRIPTION
## Summary
- allow specifying custom rules directory and polling interval
- document new flags in README
- add env variable `APPFLOW_RULES_DIR`
- add `--once` flag to run rules one time

## Testing
- `python -m py_compile main/appflow.py main/core/rule_engine.py main/utils/system.py main/utils/logger.py`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68504d962170832287cfd6b32d9bbf59