### PR TITLE
Add rule refresh to frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@
 - Interface utilisateur en **Electron**
 - Support des **profils d’usage** (travail, gaming, repos, etc.)
 - Historique et logs d'exécution
+- Consultation des logs dans l'interface (rafraîchissement auto)
+- Lancement manuel des règles depuis l'interface
+- Démarrage et arrêt du moteur depuis l'interface
+- Affichage de l'état du moteur dans l'interface
+- Rafraîchissement de la liste des règles depuis l'interface
 
 ---
 
@@ -75,6 +80,10 @@ L'interface est une app Electron avec React (ou Vue/Svelte selon choix). Elle co
 
 * une API Flask locale
 * ou une communication IPC via Node bindings (ex: `python-shell`, `zerorpc`, `child_process`)
+
+Une fois l'application Electron lancée, cliquez sur une règle pour l'exécuter manuellement.
+Utilisez les boutons **Démarrer** et **Arrêter** pour contrôler le moteur.
+La zone de logs se met à jour automatiquement, et le bouton "Actualiser la liste" permet de recharger les règles depuis les fichiers YAML.
 
 ---
 

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -7,7 +7,17 @@
 <body>
   <h1>Welcome to AppFlow</h1>
   <h2>Règles disponibles</h2>
+  <p>Cliquez sur une règle pour l'exécuter</p>
+  <button id="refresh-rules">Actualiser la liste</button>
   <ul id="rules"></ul>
+
+  <button id="start-engine">Démarrer l'automatisation</button>
+  <button id="stop-engine">Arrêter</button>
+  <span id="engine-state"></span>
+
+  <h2>Logs</h2>
+  <button id="refresh-log">Actualiser</button> <span id="auto-note">(mise à jour auto)</span>
+  <pre id="log" style="white-space: pre-wrap; background: #eee; padding: 10px; max-height: 200px; overflow: auto;"></pre>
 
   <script src="renderer.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- add a button to reload rules in the UI
- refresh rule list automatically every few seconds
- document the new capability in README with usage notes

## Testing
- `node --check frontend/main.js`
- `node --check frontend/public/renderer.js`


------
https://chatgpt.com/codex/tasks/task_e_68504d903ebc832280c33db728ae277e