### PR TITLE
Add root start script

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Simple script to start the backend and frontend.
+
+PYTHON_BIN=${PYTHON:-python3}
+
+# Start the Python backend in background
+$PYTHON_BIN main/appflow.py &
+BACKEND_PID=$!
+
+# Ensure the backend is stopped when the script exits
+trap "kill $BACKEND_PID 2>/dev/null" EXIT
+
+# Launch the Electron frontend
+cd frontend
+npm start


### PR DESCRIPTION
## Summary
- add `start.sh` for launching backend and frontend together

## Testing
- `bash -n start.sh`

------
https://chatgpt.com/codex/tasks/task_e_68505271735083229d3636d200286449